### PR TITLE
[ion/simulator] Add command-line arguments support

### DIFF
--- a/ion/src/simulator/shared/main_sdl.cpp
+++ b/ion/src/simulator/shared/main_sdl.cpp
@@ -14,6 +14,7 @@
 
 static bool argument_screen_only = false;
 static bool argument_fullscreen = false;
+static bool argument_unresizable = false;
 
 void Ion::Timing::msleep(uint32_t ms) {
   SDL_Delay(ms);
@@ -24,6 +25,7 @@ void print_help(char * program_name) {
   printf("Options:\n");
   printf("  -f, --fullscreen          Starts the emulator in fullscreen\n");
   printf("  -s, --screen-only         Disable the keyboard.\n");
+  printf("  -u, --unresizable         Disable resizing the window.\n");
   printf("  -h, --help                Show this help menu.\n");
 }
 
@@ -38,6 +40,8 @@ int main(int argc, char * argv[]) {
       argument_screen_only = true;
     } else if(strcmp(argv[i], "-f")==0 || strcmp(argv[i], "--fullscreen")==0) {
       argument_fullscreen = true;
+    } else if(strcmp(argv[i], "-u")==0 || strcmp(argv[i], "--unresizable")==0) {
+      argument_unresizable = true;
     }
   }
 
@@ -78,7 +82,7 @@ void init() {
     return;
   }
 
-  uint32_t sdl_window_args = SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_RESIZABLE;
+  uint32_t sdl_window_args = SDL_WINDOW_ALLOW_HIGHDPI | (argument_unresizable ? 0 : SDL_WINDOW_RESIZABLE);
 
   if (argument_fullscreen) {
     sdl_window_args = SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_FULLSCREEN;

--- a/ion/src/simulator/shared/main_sdl.cpp
+++ b/ion/src/simulator/shared/main_sdl.cpp
@@ -132,10 +132,18 @@ void relayout() {
   SDL_RenderSetLogicalSize(sRenderer, windowWidth, windowHeight);
 
   if (argument_screen_only) {
-    sScreenRect.x = 0;
-    sScreenRect.y = 0;
-    sScreenRect.w = windowWidth;
-    sScreenRect.h = windowHeight;
+    // Keep original aspect ration in screen_only mode.
+    float scale = (float)(Ion::Display::Width) / (float)(Ion::Display::Height);
+    if ((float)(windowHeight) * scale > float(windowWidth)) {
+      sScreenRect.w = windowWidth;
+      sScreenRect.h = (int)((float)(windowWidth) / scale);
+    } else {
+      sScreenRect.w = (int)((float)(windowHeight) * scale);
+      sScreenRect.h = windowHeight;
+    }
+
+    sScreenRect.x = (windowWidth - sScreenRect.w) / 2;
+    sScreenRect.y = (windowHeight - sScreenRect.h) / 2;
   } else {
     Layout::recompute(windowWidth, windowHeight);
     SDL_Rect backgroundRect;

--- a/ion/src/simulator/shared/platform.h
+++ b/ion/src/simulator/shared/platform.h
@@ -17,14 +17,10 @@ void IonSimulatorTelemetryInit();
 void IonSimulatorTelemetryEvent(const char * eventName);
 void IonSimulatorTelemetryDeinit();
 
-#if EPSILON_SDL_SCREEN_ONLY
-
 void IonSimulatorKeyboardKeyDown(int keyNumber);
 void IonSimulatorKeyboardKeyUp(int keyNumber);
 
 void IonSimulatorEventsPushEvent(int eventNumber);
-
-#endif
 
 void IonSimulatorCallbackDidRefresh();
 void IonSimulatorCallbackDidScanKeyboard();


### PR DESCRIPTION
Added arguments for screen-only mode, fullscreen and a usage menu, while still keeping the original functionality of the EPSILON_SDL_SCREEN_ONLY preprocessor var.