### PR TITLE
Made workshop work again, fixed #10

### DIFF
--- a/ion/src/shared/platform_info.cpp
+++ b/ion/src/shared/platform_info.cpp
@@ -69,14 +69,14 @@ private:
   constexpr static uint32_t Magic = 0xDEC00DF0;
   uint32_t m_header;
   const char m_version[8];
-  const char m_customVersion[16];
-#ifdef USERNAME
-  const char m_username[16];
-#endif
   const char m_patchLevel[8];
   void * m_storageAddress;
   size_t m_storageSize;
   uint32_t m_footer;
+  const char m_customVersion[16];
+#ifdef USERNAME
+  const char m_username[16];
+#endif
 };
 
 constexpr PlatformInfo HEADER_SECTION platform_infos;


### PR DESCRIPTION
It seems like the workshop is reading data stored in platform_info.cpp. Moving the custom data (omega firmware version and username) to the end made the workshop work again.