### PR TITLE
Added support for shift+(+/-) to change brightness

### DIFF
--- a/apps/apps_container.cpp
+++ b/apps/apps_container.cpp
@@ -220,6 +220,12 @@ bool AppsContainer::processEvent(Ion::Events::Event event) {
     suspend(true);
     return true;
   }
+  if (event == Ion::Events::BrightnessPlus || event == Ion::Events::BrightnessMinus) {
+      int delta = Ion::Backlight::MaxBrightness/GlobalPreferences::NumberOfBrightnessStates;
+      int direction = (event == Ion::Events::BrightnessPlus) ? delta : -delta;
+      GlobalPreferences::sharedGlobalPreferences()->setBrightnessLevel(GlobalPreferences::sharedGlobalPreferences()->brightnessLevel()+direction);
+    return true;
+  }
   return false;
 }
 

--- a/ion/include/ion/events.h
+++ b/ion/include/ion/events.h
@@ -139,6 +139,9 @@ constexpr Event Equal = Event::ShiftKey(Keyboard::Key::E4);
 constexpr Event Lower = Event::ShiftKey(Keyboard::Key::E5);
 constexpr Event Greater = Event::ShiftKey(Keyboard::Key::E6);
 
+constexpr Event BrightnessPlus = Event::ShiftKey(Keyboard::Key::H4);
+constexpr Event BrightnessMinus = Event::ShiftKey(Keyboard::Key::H5);
+
 // Alpha
 
 constexpr Event Colon = Event::AlphaKey(Keyboard::Key::C3);

--- a/ion/src/shared/events.cpp
+++ b/ion/src/shared/events.cpp
@@ -63,7 +63,7 @@ static constexpr EventData s_dataForEvent[4*Event::PageSize] = {
   T(k_arcSine), T(k_arcCosine), T(k_arcTangent), T("="), T("<"), T(">"),
   U(), U(), U(), U(), U(), U(),
   U(), U(), U(), U(), U(), U(),
-  U(), U(), U(), U(), U(), U(),
+  U(), U(), U(), TL(), TL(), U(),
   U(), U(), U(), U(), U(), U(),
 // Alpha
   U(), U(), U(), U(), U(), U(),
@@ -163,7 +163,7 @@ static constexpr const char * s_nameForEvent[255] = {
   "Arcsine", "Arccosine", "Arctangent", "Equal", "Lower", "Greater",
   nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
   nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-  nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+  nullptr, nullptr, nullptr, "BrightnessPlus", "BrightnessMinus", nullptr,
   nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
   //Alpha,
   nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,


### PR DESCRIPTION
I have no idea if this still works, however, it shouldn't be too hard to fix any conflicts. Please see https://github.com/numworks/epsilon/pull/940 for the description.