### PR TITLE
Fixed 2.4GB internal.bin

### DIFF
--- a/build/targets.device.mak
+++ b/build/targets.device.mak
@@ -65,7 +65,7 @@ $(BUILD_DIR)/bench.flash.$(EXE): $(call object_for,$(bench_src))
 %.two_binaries: %.elf
 	@echo "Building an internal and an external binary for     $<"
 	$(Q) $(OBJCOPY) -O binary -j .text.external -j .rodata.external $< $(basename $<).external.bin
-	$(Q) $(OBJCOPY) -O binary -R .text.external -R .rodata.external $< $(basename $<).internal.bin
+	$(Q) $(OBJCOPY) -O binary -R .text.external -R .rodata.external -R .exam_mode_buffer $< $(basename $<).internal.bin
 	@echo "Padding $(basename $<).external.bin and $(basename $<).internal.bin"
 	$(Q) printf "\xFF\xFF\xFF\xFF" >> $(basename $<).external.bin
 	$(Q) printf "\xFF\xFF\xFF\xFF" >> $(basename $<).internal.bin


### PR DESCRIPTION
That bug has been introduced by 12.4.0, as this update added a new section (.exam_mode_buffer) located at 0x90000000. objcopy was including that section, which made the file 0x90000000 bytes long.