### PR TITLE
Remove External app for unsupported devices (web/n0100) and adds a ba…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ include build/config.mak
 ifeq (${DEVICE}, n0110)
   apps_list = ${EPSILON_APPS}
 else
-  ifdef FORCE_EXTERNAL
-    apps_list = ${EPSILON_APPS}
-  else
-    apps_list = $(foreach i, ${EPSILON_APPS}, $(if $(filter external, $(i)),,$(i)))
-  endif
+  apps_list = $(foreach i, ${EPSILON_APPS}, $(if $(filter external, $(i)),,$(i)))
+endif
+
+ifdef FORCE_EXTERNAL
+  apps_list = ${EPSILON_APPS}
 endif
 
 # Disable default Make rules

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include build/config.mak
 
-ifeq (${DEVICE}, n0110)
+ifeq (${MODEL}, n0110)
   apps_list = ${EPSILON_APPS}
 else
   apps_list = $(foreach i, ${EPSILON_APPS}, $(if $(filter external, $(i)),,$(i)))

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 include build/config.mak
 
+ifeq (${DEVICE}, n0110)
+  apps_list = ${EPSILON_APPS}
+else
+  apps_list = $(foreach i, ${EPSILON_APPS}, $(if $(filter external, $(i)),,$(i)))
+endif
+
 # Disable default Make rules
 .SUFFIXES:
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,11 @@ include build/config.mak
 ifeq (${DEVICE}, n0110)
   apps_list = ${EPSILON_APPS}
 else
-  apps_list = $(foreach i, ${EPSILON_APPS}, $(if $(filter external, $(i)),,$(i)))
+  ifdef FORCE_EXTERNAL
+    apps_list = ${EPSILON_APPS}
+  else
+    apps_list = $(foreach i, ${EPSILON_APPS}, $(if $(filter external, $(i)),,$(i)))
+  endif
 endif
 
 # Disable default Make rules

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -3,12 +3,12 @@ include apps/home/Makefile
 include apps/on_boarding/Makefile
 include apps/hardware_test/Makefile
 include apps/usb/Makefile
-apps =
 
+apps =
 # All selected apps are included. Each Makefile below is responsible for setting
 # the $apps variable (name of the app class) and the $app_headers
 # (path to the apps header).
-$(foreach i,${EPSILON_APPS},$(eval include apps/$(i)/Makefile))
+$(foreach i,${apps_list},${eval include apps/$(i)/Makefile})
 
 app_src += $(addprefix apps/,\
   apps_container.cpp \
@@ -43,7 +43,7 @@ snapshots_construction = $(foreach i,$(apps),,m_snapshot$(subst :,,$(i))Snapshot
 snapshots_list = $(foreach i,$(apps),,&m_snapshot$(subst :,,$(i))Snapshot)
 snapshots_count = $(words $(apps))
 snapshot_includes = $(foreach i,$(app_headers),-include $(i) )
-epsilon_app_names = '$(foreach i,${EPSILON_APPS},"$(i)", )'
+epsilon_app_names = '$(foreach i,${apps_list},"$(i)", )'
 
 $(call object_for,apps/apps_container_storage.cpp apps/apps_container.cpp apps/main.cpp): CXXFLAGS += $(snapshot_includes) -DAPPS_CONTAINER_APPS_DECLARATION="$(apps_declaration)" -DAPPS_CONTAINER_SNAPSHOT_DECLARATIONS="$(snapshots_declaration)" -DAPPS_CONTAINER_SNAPSHOT_CONSTRUCTORS="$(snapshots_construction)" -DAPPS_CONTAINER_SNAPSHOT_LIST="$(snapshots_list)" -DAPPS_CONTAINER_SNAPSHOT_COUNT=$(snapshots_count) -DEPSILON_APPS_NAMES=$(epsilon_app_names) -DUSERNAME="$(USERNAME)"
 

--- a/apps/calculation/app.cpp
+++ b/apps/calculation/app.cpp
@@ -17,6 +17,10 @@ I18n::Message App::Descriptor::upperName() {
   return I18n::Message::CalculAppCapital;
 }
 
+int App::Descriptor::examinationLevel() {
+  return App::Descriptor::StrictExaminationLevel;
+}
+
 const Image * App::Descriptor::icon() {
   return ImageStore::CalculationIcon;
 }

--- a/apps/calculation/app.h
+++ b/apps/calculation/app.h
@@ -15,6 +15,7 @@ public:
   public:
     I18n::Message name() override;
     I18n::Message upperName() override;
+    int examinationLevel() override;
     const Image * icon() override;
   };
   class Snapshot : public ::App::Snapshot {

--- a/apps/code/app.cpp
+++ b/apps/code/app.cpp
@@ -14,6 +14,10 @@ I18n::Message App::Descriptor::upperName() {
   return I18n::Message::CodeAppCapital;
 }
 
+int App::Descriptor::examinationLevel() {
+  return App::Descriptor::BasicExaminationLevel;
+}
+
 const Image * App::Descriptor::icon() {
   return ImageStore::CodeIcon;
 }

--- a/apps/code/app.h
+++ b/apps/code/app.h
@@ -18,6 +18,7 @@ public:
   public:
     I18n::Message name() override;
     I18n::Message upperName() override;
+    int examinationLevel() override;
     const Image * icon() override;
   };
   class Snapshot : public ::App::Snapshot {

--- a/apps/external/app.cpp
+++ b/apps/external/app.cpp
@@ -12,6 +12,10 @@ I18n::Message App::Descriptor::upperName() {
   return I18n::Message::ExternalAppCapital;
 }
 
+int App::Descriptor::examinationLevel() {
+  return App::Descriptor::BasicExaminationLevel;
+}
+
 const Image * App::Descriptor::icon() {
   return ImageStore::ExternalIcon;
 }

--- a/apps/external/app.h
+++ b/apps/external/app.h
@@ -12,6 +12,7 @@ public:
   public:
     I18n::Message name() override;
     I18n::Message upperName() override;
+    int examinationLevel() override;
     const Image * icon() override;
   };
   class Snapshot : public ::App::Snapshot {

--- a/apps/graph/app.cpp
+++ b/apps/graph/app.cpp
@@ -16,6 +16,10 @@ I18n::Message App::Descriptor::upperName() {
   return I18n::Message::FunctionAppCapital;
 }
 
+int App::Descriptor::examinationLevel() {
+  return App::Descriptor::StrictExaminationLevel;
+}
+
 const Image * App::Descriptor::icon() {
   return ImageStore::GraphIcon;
 }

--- a/apps/graph/app.h
+++ b/apps/graph/app.h
@@ -17,6 +17,7 @@ public:
   public:
     I18n::Message name() override;
     I18n::Message upperName() override;
+    int examinationLevel() override;
     const Image * icon() override;
   };
   class Snapshot : public Shared::FunctionApp::Snapshot {

--- a/apps/home/controller.cpp
+++ b/apps/home/controller.cpp
@@ -59,8 +59,10 @@ bool Controller::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::OK || event == Ion::Events::EXE) {
     AppsContainer * container = AppsContainer::sharedAppsContainer();
     ::App::Snapshot * selectedSnapshot = container->appSnapshotAtIndex(selectionDataSource()->selectedRow()*k_numberOfColumns+selectionDataSource()->selectedColumn()+1);
-    if ((GlobalPreferences::sharedGlobalPreferences()->examMode() == GlobalPreferences::ExamMode::Dutch || GlobalPreferences::sharedGlobalPreferences()->examMode() == GlobalPreferences::ExamMode::NoSym) &&
-      (selectedSnapshot->descriptor()->name() == I18n::Message::CodeApp || selectedSnapshot->descriptor()->name() == I18n::Message::ExternalApp)) {
+    if (((GlobalPreferences::sharedGlobalPreferences()->examMode() == GlobalPreferences::ExamMode::Dutch || GlobalPreferences::sharedGlobalPreferences()->examMode() == GlobalPreferences::ExamMode::NoSym) &&
+      (selectedSnapshot->descriptor()->examinationLevel() < 2)) ||
+      ((GlobalPreferences::sharedGlobalPreferences()->examMode() == GlobalPreferences::ExamMode::Standard) && (selectedSnapshot->descriptor()->examinationLevel() < 1))) {
+      //(selectedSnapshot->descriptor()->name() == I18n::Message::CodeApp || selectedSnapshot->descriptor()->name() == I18n::Message::ExternalApp)) {
       App::app()->displayWarning(I18n::Message::ForbidenAppInExamMode1, I18n::Message::ForbidenAppInExamMode2);
     } else {
       bool switched = container->switchTo(selectedSnapshot);

--- a/apps/home/controller.cpp
+++ b/apps/home/controller.cpp
@@ -59,10 +59,8 @@ bool Controller::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::OK || event == Ion::Events::EXE) {
     AppsContainer * container = AppsContainer::sharedAppsContainer();
     ::App::Snapshot * selectedSnapshot = container->appSnapshotAtIndex(selectionDataSource()->selectedRow()*k_numberOfColumns+selectionDataSource()->selectedColumn()+1);
-    if (((GlobalPreferences::sharedGlobalPreferences()->examMode() == GlobalPreferences::ExamMode::Dutch || GlobalPreferences::sharedGlobalPreferences()->examMode() == GlobalPreferences::ExamMode::NoSym) &&
-      (selectedSnapshot->descriptor()->examinationLevel() < 2)) ||
-      ((GlobalPreferences::sharedGlobalPreferences()->examMode() == GlobalPreferences::ExamMode::Standard) && (selectedSnapshot->descriptor()->examinationLevel() < 1))) {
-      //(selectedSnapshot->descriptor()->name() == I18n::Message::CodeApp || selectedSnapshot->descriptor()->name() == I18n::Message::ExternalApp)) {
+    if (GlobalPreferences::sharedGlobalPreferences()->examMode() == GlobalPreferences::ExamMode::Dutch && selectedSnapshot->descriptor()->examinationLevel() < 2) ||
+      ((GlobalPreferences::sharedGlobalPreferences()->examMode() == GlobalPreferences::ExamMode::Standard || GlobalPreferences::sharedGlobalPreferences()->examMode() == GlobalPreferences::ExamMode::NoSym) && selectedSnapshot->descriptor()->examinationLevel() < 1)) {
       App::app()->displayWarning(I18n::Message::ForbidenAppInExamMode1, I18n::Message::ForbidenAppInExamMode2);
     } else {
       bool switched = container->switchTo(selectedSnapshot);

--- a/apps/home/controller.cpp
+++ b/apps/home/controller.cpp
@@ -59,7 +59,7 @@ bool Controller::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::OK || event == Ion::Events::EXE) {
     AppsContainer * container = AppsContainer::sharedAppsContainer();
     ::App::Snapshot * selectedSnapshot = container->appSnapshotAtIndex(selectionDataSource()->selectedRow()*k_numberOfColumns+selectionDataSource()->selectedColumn()+1);
-    if (GlobalPreferences::sharedGlobalPreferences()->examMode() == GlobalPreferences::ExamMode::Dutch && selectedSnapshot->descriptor()->examinationLevel() < 2) ||
+    if ((GlobalPreferences::sharedGlobalPreferences()->examMode() == GlobalPreferences::ExamMode::Dutch && selectedSnapshot->descriptor()->examinationLevel() < 2) ||
       ((GlobalPreferences::sharedGlobalPreferences()->examMode() == GlobalPreferences::ExamMode::Standard || GlobalPreferences::sharedGlobalPreferences()->examMode() == GlobalPreferences::ExamMode::NoSym) && selectedSnapshot->descriptor()->examinationLevel() < 1)) {
       App::app()->displayWarning(I18n::Message::ForbidenAppInExamMode1, I18n::Message::ForbidenAppInExamMode2);
     } else {

--- a/apps/probability/app.cpp
+++ b/apps/probability/app.cpp
@@ -15,6 +15,10 @@ I18n::Message App::Descriptor::upperName() {
   return I18n::Message::ProbaAppCapital;
 }
 
+int App::Descriptor::examinationLevel() {
+  return App::Descriptor::StrictExaminationLevel;
+}
+
 const Image * App::Descriptor::icon() {
   return ImageStore::ProbabilityIcon;
 }

--- a/apps/probability/app.h
+++ b/apps/probability/app.h
@@ -27,6 +27,7 @@ public:
     public:
       I18n::Message name() override;
       I18n::Message upperName() override;
+      int examinationLevel() override;
       const Image * icon() override;
   };
   class Snapshot : public ::App::Snapshot {

--- a/apps/regression/app.cpp
+++ b/apps/regression/app.cpp
@@ -14,6 +14,10 @@ I18n::Message App::Descriptor::upperName() {
   return I18n::Message::RegressionAppCapital;
 }
 
+int App::Descriptor::examinationLevel() {
+  return App::Descriptor::StrictExaminationLevel;
+}
+
 const Image * App::Descriptor::icon() {
   return ImageStore::RegressionIcon;
 }

--- a/apps/regression/app.h
+++ b/apps/regression/app.h
@@ -17,6 +17,7 @@ public:
   public:
     I18n::Message name() override;
     I18n::Message upperName() override;
+    int examinationLevel() override;
     const Image * icon() override;
   };
   class Snapshot : public ::App::Snapshot, public TabViewDataSource {

--- a/apps/sequence/app.cpp
+++ b/apps/sequence/app.cpp
@@ -14,6 +14,10 @@ I18n::Message App::Descriptor::upperName() {
   return I18n::Message::SequenceAppCapital;
 }
 
+int App::Descriptor::examinationLevel() {
+  return App::Descriptor::StrictExaminationLevel;
+}
+
 const Image * App::Descriptor::icon() {
   return ImageStore::SequenceIcon;
 }

--- a/apps/sequence/app.h
+++ b/apps/sequence/app.h
@@ -19,6 +19,7 @@ public:
   public:
     I18n::Message name() override;
     I18n::Message upperName() override;
+    int examinationLevel() override;
     const Image * icon() override;
   };
   class Snapshot : public Shared::FunctionApp::Snapshot {

--- a/apps/settings/app.cpp
+++ b/apps/settings/app.cpp
@@ -12,6 +12,10 @@ I18n::Message App::Descriptor::upperName() {
   return I18n::Message::SettingsAppCapital;
 }
 
+int App::Descriptor::examinationLevel() {
+  return App::Descriptor::StrictExaminationLevel;
+}
+
 const Image * App::Descriptor::icon() {
   return ImageStore::SettingsIcon;
 }

--- a/apps/settings/app.h
+++ b/apps/settings/app.h
@@ -12,6 +12,7 @@ public:
   public:
     I18n::Message name() override;
     I18n::Message upperName() override;
+    int examinationLevel() override;
     const Image * icon() override;
   };
   class Snapshot : public ::App::Snapshot {

--- a/apps/solver/app.cpp
+++ b/apps/solver/app.cpp
@@ -14,6 +14,10 @@ I18n::Message App::Descriptor::upperName() {
   return I18n::Message::SolverAppCapital;
 }
 
+int App::Descriptor::examinationLevel() {
+  return App::Descriptor::StrictExaminationLevel;
+}
+
 const Image * App::Descriptor::icon() {
   return ImageStore::SolverIcon;
 }

--- a/apps/solver/app.h
+++ b/apps/solver/app.h
@@ -16,6 +16,7 @@ public:
     public:
       I18n::Message name() override;
       I18n::Message upperName() override;
+      int examinationLevel() override;
       const Image * icon() override;
   };
   class Snapshot : public ::App::Snapshot {

--- a/apps/statistics/app.cpp
+++ b/apps/statistics/app.cpp
@@ -14,6 +14,10 @@ I18n::Message App::Descriptor::upperName() {
   return I18n::Message::StatsAppCapital;
 }
 
+int App::Descriptor::examinationLevel() {
+  return App::Descriptor::StrictExaminationLevel;
+}
+
 const Image * App::Descriptor::icon() {
   return ImageStore::StatIcon;
 }

--- a/apps/statistics/app.h
+++ b/apps/statistics/app.h
@@ -17,6 +17,7 @@ public:
   public:
     I18n::Message name() override;
     I18n::Message upperName() override;
+    int examinationLevel() override;
     const Image * icon() override;
   };
   class Snapshot : public ::App::Snapshot, public TabViewDataSource {

--- a/escher/include/escher/app.h
+++ b/escher/include/escher/app.h
@@ -27,7 +27,12 @@ public:
   public:
     virtual I18n::Message name();
     virtual I18n::Message upperName();
+    virtual int examinationLevel();
     virtual const Image * icon();
+
+    const int NoExaminationLevel = 0;
+    const int BasicExaminationLevel = 1;
+    const int StrictExaminationLevel = 2;
   };
   class Snapshot {
   public:

--- a/escher/src/app.cpp
+++ b/escher/src/app.cpp
@@ -13,6 +13,10 @@ I18n::Message App::Descriptor::upperName() {
   return (I18n::Message)0;
 }
 
+int App::Descriptor::examinationLevel() {
+  return App::Descriptor::NoExaminationLevel;
+}
+
 const Image * App::Descriptor::icon() {
   return nullptr;
 }


### PR DESCRIPTION
This pull request makes two changes inside apps system of Omega.

# Improving
 * The External app is removed from unsupported targets such as web, Numwork n0100 and Android application in order to clean home page from useless icons.
 * Examination mode checking, initially checking the name of the app to make unavailable, now check a value called `examinationLevel` in the class `App::Descriptor` in order to make easier checking when the application can be used or not. It allows three levels of access:
    * The level 0 called `NoExaminationLevel` used by applications forbidden in all countries with examination mode policy
    * The level 1 called `BasicExaminationLevel` used by application allowed with the Standard examination mode but disallowed in No Sym/Dutch examination mode.
    * The level 2 called `StrictExaminationLevel` used by application allowed in all cases.

# Issue
The examination mode checking is not implemented in epsilon and the default examination level is 0. The consequence is that added element can be only used without examination mod if it is not adapted.