### PR TITLE
Fixed result display bug with sin/cos/tan

### DIFF
--- a/apps/calculation/calculation.cpp
+++ b/apps/calculation/calculation.cpp
@@ -165,7 +165,7 @@ KDCoordinate Calculation::height(Context * context, bool expanded, bool allExpre
     if (singleLine && Poincare::Preferences::sharedPreferences()->resultDisplay() == Poincare::Preferences::ResultDisplay::Compact) {
       if (allExpressionsInline) {
         KDCoordinate exactOutputBaseline = exactLayout.baseline();
-        result = (inputHeight >= exactOutputHeight) ? maxCoordinate(inputBaseline, exactOutputBaseline) + singleMargin : maxCoordinate(inputHeight - inputBaseline, exactOutputHeight-exactOutputBaseline) + singleMargin;
+        result = maxCoordinate(inputBaseline, exactOutputBaseline) + maxCoordinate(inputHeight - inputBaseline, exactOutputHeight-exactOutputBaseline)+doubleMargin;
       } else {
         result = (inputHeight >= exactOutputHeight) ? inputHeight + singleMargin : exactOutputHeight + singleMargin;
       }
@@ -203,7 +203,7 @@ KDCoordinate Calculation::height(Context * context, bool expanded, bool allExpre
       if (singleLine && Poincare::Preferences::sharedPreferences()->resultDisplay() == Poincare::Preferences::ResultDisplay::Compact) {
         if (allExpressionsInline) {
           KDCoordinate approximateOutputBaseline = approximateLayout.baseline();
-          result = (inputHeight >= approximateOutputHeight) ? maxCoordinate(inputBaseline, approximateOutputBaseline) + singleMargin : maxCoordinate(inputHeight - inputBaseline, approximateOutputHeight-approximateOutputBaseline) + singleMargin;
+          result = maxCoordinate(inputBaseline, approximateOutputBaseline) + maxCoordinate(inputHeight - inputBaseline, approximateOutputHeight-approximateOutputBaseline) + doubleMargin + singleMargin;
         } else {
           result = (inputHeight >= approximateOutputHeight) ? inputHeight + singleMargin : approximateOutputHeight + singleMargin;
         }
@@ -227,7 +227,7 @@ KDCoordinate Calculation::height(Context * context, bool expanded, bool allExpre
       if (singleLine && Poincare::Preferences::sharedPreferences()->resultDisplay() == Poincare::Preferences::ResultDisplay::Compact) {
         KDCoordinate outputHeight = maxCoordinate(exactOutputBaseline, approximateOutputBaseline) + maxCoordinate(exactOutputHeight-exactOutputBaseline, approximateOutputHeight-approximateOutputBaseline);
         if (allExpressionsInline) {
-          result = (inputHeight >= outputHeight) ? maxCoordinate(inputBaseline, maxCoordinate(exactOutputBaseline, approximateOutputBaseline)) + singleMargin : maxCoordinate(inputHeight - inputBaseline, maxCoordinate(exactOutputHeight - exactOutputBaseline, approximateOutputHeight-approximateOutputBaseline)) + singleMargin;
+          result = maxCoordinate(inputBaseline, maxCoordinate(exactOutputBaseline, approximateOutputBaseline)) + maxCoordinate(inputHeight - inputBaseline, maxCoordinate(exactOutputHeight - exactOutputBaseline, approximateOutputHeight-approximateOutputBaseline));
         } else {
           result = (inputHeight >= outputHeight) ? inputHeight + singleMargin : outputHeight + singleMargin;
         }


### PR DESCRIPTION
The sin/cos/tan compact result display bug is now fixed
![BugFixed](https://user-images.githubusercontent.com/29680628/74983458-a8ac9200-53fb-11ea-940c-3f0f1ae4dc37.png)
