### PR TITLE
[Fix] Fixed the display bug with the default display mode

### DIFF
--- a/apps/calculation/history_view_cell.cpp
+++ b/apps/calculation/history_view_cell.cpp
@@ -186,7 +186,7 @@ void HistoryViewCell::layoutSubviews(bool force) {
   force);
   KDSize outputSize = m_scrollableOutputView.minimalSizeForOptimalDisplay();
   int singleLine = outputSize.width() + inputSize.width() < bounds().width() - 6;
-  int outputHeight = (singleLine) ? (maxCoordinate(0, inputSize.height() - outputSize.height()) / 2) + maxCoordinate(0, (inputSize.height() - outputSize.height()) / 2) : inputSize.height();
+  int outputHeight = (singleLine && Poincare::Preferences::sharedPreferences()->resultDisplay() == Poincare::Preferences::ResultDisplay::Compact) ? (maxCoordinate(0, inputSize.height() - outputSize.height()) / 2) + maxCoordinate(0, (inputSize.height() - outputSize.height()) / 2) : inputSize.height();
   m_scrollableOutputView.setFrame(KDRect(
     maxCoordinate(0, maxFrameWidth - outputSize.width()),
     outputHeight,


### PR DESCRIPTION
I forgot to re include `&& Poincare::Preferences::sharedPreferences()->resultDisplay() == Poincare::Preferences::ResultDisplay::Compact`. oops