### PR TITLE
[build] Enable jobserver lto.

### DIFF
--- a/build/toolchain.arm-gcc.mak
+++ b/build/toolchain.arm-gcc.mak
@@ -20,7 +20,7 @@ endif
 
 ifeq ($(LTO),1)
 # Use link-time optimization if LTO=1
-SFLAGS += -flto
+SFLAGS += -flto=auto
 endif
 
 # Get rid of unused symbols. This is also useful even if LTO=1.


### PR DESCRIPTION
Makes huge improvement.

Comparison :

With -flto (FULLBUILD)
```
real    2m46,454s
user    5m15,978s
sys    0m35,063s
```
With -flto=jobserver (FULLBUILD)
```
real    1m36,405s
user    5m25,388s
sys    0m39,771s
```
With -flto (Linking only)
```
real    1m22,670s
user    1m17,455s
sys    0m4,321s
```
With -flto=jobserver (Linking only)
```
real    0m45,516s
user    1m38,155s
sys    0m5,931s
```