### PR TITLE
Enabled circuit breaker with emscripten

### DIFF
--- a/apps/apps_container.cpp
+++ b/apps/apps_container.cpp
@@ -37,7 +37,7 @@ AppsContainer::AppsContainer() :
   m_usbConnectedSnapshot()
 {
   m_emptyBatteryWindow.setFrame(KDRect(0, 0, Ion::Display::Width, Ion::Display::Height), false);
-#if __EMSCRIPTEN__
+// #if __EMSCRIPTEN__
   /* AppsContainer::poincareCircuitBreaker uses Ion::Keyboard::scan(), which
    * calls emscripten_sleep. If we set the poincare circuit breaker, we would
    * need to whitelist all the methods that might be in the call stack when
@@ -47,9 +47,13 @@ AppsContainer::AppsContainer() :
    * quite painy to maintain).
    * We just remove the circuit breaker for now.
    * TODO: Put the Poincare circuit breaker back on epsilon's web emulator */
-#else
+
+  /*
+   * This can be run in Omega, since it uses WebASM.
+   */
+// #else
   Poincare::Expression::SetCircuitBreaker(AppsContainer::poincareCircuitBreaker);
-#endif
+// #endif
   Ion::Storage::sharedStorage()->setDelegate(this);
 }
 

--- a/apps/code/console_controller.cpp
+++ b/apps/code/console_controller.cpp
@@ -447,7 +447,7 @@ void ConsoleController::printText(const char * text, size_t length) {
     flushOutputAccumulationBufferToStore();
     micropython_port_vm_hook_refresh_print();
   }
-#if __EMSCRIPTEN__
+// #if __EMSCRIPTEN__
   /* If we called micropython_port_interrupt_if_needed here, we would need to
    * put in the WHITELIST all the methods that call
    * ConsoleController::printText, which means all the MicroPython methods that
@@ -460,13 +460,17 @@ void ConsoleController::printText(const char * text, size_t length) {
    * device.
    *
    * TODO: Allow print interrpution on emscripten -> maybe by using WASM=1 ? */
-#else
+
+  /*
+   * This can be run in Omega, since it uses WebASM.
+   */
+// #else
   /* micropython_port_vm_hook_loop is not enough to detect user interruptions,
    * because it calls micropython_port_interrupt_if_needed every 20000
    * operations, and a print operation is quite long. We thus explicitely call
    * micropython_port_interrupt_if_needed here. */
   micropython_port_interrupt_if_needed();
-#endif
+// #endif
 }
 
 void ConsoleController::autoImportScript(Script script, bool force) {


### PR DESCRIPTION
This is possible because we use WASM and ASYNCIFY with the latest-upstream toolchain.