### PR TITLE
[Settings] Language Disabled

### DIFF
--- a/apps/settings/main_controller_prompt_none.cpp
+++ b/apps/settings/main_controller_prompt_none.cpp
@@ -10,7 +10,7 @@ constexpr SettingsMessageTree s_modelMenu[] =
   {SettingsMessageTree(I18n::Message::MathOptions, s_modelMathOptionsChildren),
     SettingsMessageTree(I18n::Message::Brightness),
     SettingsMessageTree(I18n::Message::DateTime, s_modelDateTimeChildren),
-    SettingsMessageTree(I18n::Message::Language),
+    //SettingsMessageTree(I18n::Message::Language),
     SettingsMessageTree(I18n::Message::ExamMode, ExamModeConfiguration::s_modelExamChildren),
     SettingsMessageTree(I18n::Message::FontSizes, s_modelFontChildren),
     SettingsMessageTree(I18n::Message::Accessibility, s_accessibilityChildren),


### PR DESCRIPTION
I disabled the language menu in the settings according to request #386
Only tested on n0100

-Update apps/settings/main_controller_prompt_none.cpp