### PR TITLE
Allowing the battery icon to behave less wildly in some situations

### DIFF
--- a/ion/src/device/shared/drivers/battery.cpp
+++ b/ion/src/device/shared/drivers/battery.cpp
@@ -30,7 +30,7 @@ Charge level() {
 
   constexpr static int numberOfChargeStates = 4;
   constexpr static int numberOfThresholds = numberOfChargeStates - 1;
-  constexpr float hysteresis = 0.02f;
+  constexpr float hysteresis = 0.04f;
   const float thresholds[numberOfThresholds] = {3.6f + hysteresis, 3.7f, 3.8f}; // We do not want to lower the threshold for empty battery, so we add the hysteresis to it
   int nextLevel = -1;
   for (int i = 0; i < numberOfThresholds; i++) {

--- a/ion/src/device/shared/drivers/battery.cpp
+++ b/ion/src/device/shared/drivers/battery.cpp
@@ -30,7 +30,7 @@ Charge level() {
 
   constexpr static int numberOfChargeStates = 4;
   constexpr static int numberOfThresholds = numberOfChargeStates - 1;
-  constexpr float hysteresis = 0.04f;
+  constexpr float hysteresis = 0.02f;
   const float thresholds[numberOfThresholds] = {3.6f + hysteresis, 3.7f, 3.8f}; // We do not want to lower the threshold for empty battery, so we add the hysteresis to it
   int nextLevel = -1;
   for (int i = 0; i < numberOfThresholds; i++) {


### PR DESCRIPTION
This is a potential solution to the problem that makes the battery icon behave in some "wild" ways when approchaing one of the thresholds, by augmenting the hysteresis value, I hope that the transition will be smoother. 