### PR TITLE
[Themes] Updated themes_manager.py and JSON themes

### DIFF
--- a/themes/themes/local/epsilon_dark.json
+++ b/themes/themes/local/epsilon_dark.json
@@ -1,19 +1,22 @@
 {
     "name": "Epsilon Dark",
     "icons": "epsilon_light",
+    "version": 2,
     "colors": {
-        "PrimaryText": "ffffff",
-        "SecondaryText": "585858",
-        "AccentText": "ffb734",
-        "ApproximateSignText": "737373",
-        "ApproximateExpressionText": "737373",
+        "Main": {
+            "PrimaryText": "ffffff",
+            "SecondaryText": "585858",
+            "AccentText": "ffb734",
+            "ApproximateSignText": "737373",
+            "ApproximateExpressionText": "737373"
+        },
         "Background": {
             "Hard": "000000",
             "Apps": "080605",
             "AppsSecondary": "1f1912"
         },
         "Toolbar": {
-            "": "ffb734",
+            "Main": "ffb734",
             "Text": "000000"
         },
         "ExpressionInput": {
@@ -25,7 +28,7 @@
             "SecondaryLine": "0a0a0a"
         },
         "Battery": {
-            "": "000000",
+            "Main": "000000",
             "InCharge": "ffcc7b",
             "Low": "f30211"
         },
@@ -34,7 +37,7 @@
             "Background": "262626"
         },
         "Control": {
-            "": "ffb734",
+            "Main": "ffb734",
             "Enabled": "ffb734",
             "Disabled": "585858"
         },

--- a/themes/themes/local/epsilon_light.json
+++ b/themes/themes/local/epsilon_light.json
@@ -1,19 +1,22 @@
 {
     "name": "Epsilon Light",
     "icons": "epsilon_light",
+    "version": 2,
     "colors": {
-        "PrimaryText": "000000",
-        "SecondaryText": "a7a7a7",
-        "AccentText": "ffb734",
-        "ApproximateSignText": "8c8c8c",
-        "ApproximateExpressionText": "8c8c8c",
+        "Main": {
+            "PrimaryText": "000000",
+            "SecondaryText": "a7a7a7",
+            "AccentText": "ffb734",
+            "ApproximateSignText": "8c8c8c",
+            "ApproximateExpressionText": "8c8c8c"
+        },
         "Background": {
             "Hard": "ffffff",
             "Apps": "f7f9fa",
             "AppsSecondary": "e0e6ed"
         },
         "Toolbar": {
-            "": "ffb734",
+            "Main": "ffb734",
             "Text": "ffffff"
         },
         "ExpressionInput": {
@@ -25,7 +28,7 @@
             "SecondaryLine": "f5f5f5"
         },
         "Battery": {
-            "": "ffffff",
+            "Main": "ffffff",
             "InCharge": "ffcc7b",
             "Low": "f30211"
         },
@@ -34,7 +37,7 @@
             "Background": "d9d9d9"
         },
         "Control": {
-            "": "ffb734",
+            "Main": "ffb734",
             "Enabled": "ffb734",
             "Disabled": "a7a7a7"
         },

--- a/themes/themes/local/omega_dark.json
+++ b/themes/themes/local/omega_dark.json
@@ -1,19 +1,22 @@
 {
     "name": "Omega Dark",
     "icons": "omega_dark",
+    "version": 2,
     "colors": {
-        "PrimaryText": "ffffff",
-        "SecondaryText": "949494",
-        "AccentText": "00857f",
-        "ApproximateSignText": "a6a6a6",
-        "ApproximateExpressionText": "a6a6a6",
+        "Main": {
+            "PrimaryText": "ffffff",
+            "SecondaryText": "949494",
+            "AccentText": "00857f",
+            "ApproximateSignText": "a6a6a6",
+            "ApproximateExpressionText": "a6a6a6"
+        },
         "Background": {
             "Hard": "000000",
             "Apps": "050505",
             "AppsSecondary": "0f0f0f"
         },
         "Toolbar": {
-            "": "c03535",
+            "Main": "c03535",
             "Text": "ffffff"
         },
         "ExpressionInput": {
@@ -25,7 +28,7 @@
             "SecondaryLine": "0a0a0a"
         },
         "Battery": {
-            "": "ffffff",
+            "Main": "ffffff",
             "InCharge": "179e1f",
             "Low": "992321"
         },
@@ -34,7 +37,7 @@
             "Background": "262626"
         },
         "Control": {
-            "": "00857f",
+            "Main": "00857f",
             "Enabled": "00b2b0",
             "Disabled": "616161"
         },

--- a/themes/themes/local/omega_light.json
+++ b/themes/themes/local/omega_light.json
@@ -1,19 +1,22 @@
 {
     "name": "Omega Light",
     "icons": "omega_light",
+    "version": 2,
     "colors": {
-        "PrimaryText": "000000",
-        "SecondaryText": "6e6e6e",
-        "AccentText": "00857f",
-        "ApproximateSignText": "595959",
-        "ApproximateExpressionText": "595959",
+        "Main": {
+            "PrimaryText": "000000",
+            "SecondaryText": "6e6e6e",
+            "AccentText": "00857f",
+            "ApproximateSignText": "595959",
+            "ApproximateExpressionText": "595959"
+        },
         "Background": {
             "Hard": "ffffff",
             "Apps": "fafafa",
             "AppsSecondary": "f0f0f0"
         },
         "Toolbar": {
-            "": "c03535",
+            "Main": "c03535",
             "Text": "ffffff"
         },
         "ExpressionInput": {
@@ -25,7 +28,7 @@
             "SecondaryLine": "f5f5f5"
         },
         "Battery": {
-            "": "ffffff",
+            "Main": "ffffff",
             "InCharge": "179e1f",
             "Low": "992321"
         },
@@ -34,7 +37,7 @@
             "Background": "d9d9d9"
         },
         "Control": {
-            "": "00857f",
+            "Main": "00857f",
             "Enabled": "00b2b0",
             "Disabled": "9e9e9e"
         },

--- a/themes/themes_manager.py
+++ b/themes/themes_manager.py
@@ -82,12 +82,34 @@ def write_palette_h(data, file_p):
     file_p.write("class Palette {\n")
     file_p.write("public:\n")
 
-    for key in data["colors"].keys():
-        if type(data["colors"][key]) is str:
-            file_p.write("  constexpr static KDColor " + key + " = KDColor::RGB24(0x" + data["colors"][key] + ");\n")
-        else:
-            for sub_key in data["colors"][key].keys():
-                file_p.write("  constexpr static KDColor " + key + sub_key + " = KDColor::RGB24(0x" + data["colors"][key][sub_key] + ");\n")
+    try:
+        if data["version"] == 2:
+            for key, value in data["colors"].items():
+                for sub_key, sub_value in value.items():
+                    if key == "Main":
+                        text = ("  constexpr static KDColor {} = "
+                                "KDColor::RGB24(0x{code});").format(sub_key,
+                                                                    code=sub_value)
+                    elif sub_key == "Main":
+                        text = ("  constexpr static KDColor {} = "
+                                "KDColor::RGB24(0x{code});").format(key,
+                                                                    code=sub_value)
+                    else:
+                        text = ("  constexpr static KDColor {}{} = "
+                                "KDColor::RGB24(0x{code});").format(key,
+                                                                    sub_key,
+                                                                    code=sub_value)
+
+                    file_p.write(text + "\n")
+
+    except KeyError:
+        print("THEME   Please consider updating the JSON theme file")
+        for key in data["colors"].keys():
+            if type(data["colors"][key]) is str:
+                file_p.write("  constexpr static KDColor " + key + " = KDColor::RGB24(0x" + data["colors"][key] + ");\n")
+            else:
+                for sub_key in data["colors"][key].keys():
+                    file_p.write("  constexpr static KDColor " + key + sub_key + " = KDColor::RGB24(0x" + data["colors"][key][sub_key] + ");\n")
 
     # Default values - Sometimes never used
     file_p.write("  constexpr static KDColor YellowDark = KDColor::RGB24(0xffb734);\n")


### PR DESCRIPTION
No more "alone" nor "no key" colors in JSON, and there's still retro-compatibility with older themes