### PR TITLE
[Toolbox] Add alphabetic keys to navigate in toolbox

### DIFF
--- a/escher/include/escher/nested_menu_controller.h
+++ b/escher/include/escher/nested_menu_controller.h
@@ -62,7 +62,7 @@ protected:
   static constexpr int LeafCellType = 0;
   static constexpr int NodeCellType = 1;
   int stackDepth() const;
-  bool handleEventForRow(Ion::Events::Event event, int selectedRow);
+  virtual bool handleEventForRow(Ion::Events::Event event, int selectedRow);
   virtual bool selectSubMenu(int selectedRow);
   virtual bool returnToPreviousMenu();
   virtual bool selectLeaf(int selectedRow) = 0;

--- a/escher/include/escher/toolbox.h
+++ b/escher/include/escher/toolbox.h
@@ -21,6 +21,7 @@ public:
 
 protected:
   constexpr static int k_maxMessageSize = 100;
+  bool handleEventForRow(Ion::Events::Event event, int selectedRow) override;
   bool selectSubMenu(int selectedRow) override;
   bool returnToPreviousMenu() override;
   virtual int maxNumberOfDisplayedRows() = 0;

--- a/escher/src/toolbox.cpp
+++ b/escher/src/toolbox.cpp
@@ -46,6 +46,21 @@ int Toolbox::typeAtLocation(int i, int j) {
   return NodeCellType;
 }
 
+bool Toolbox::handleEventForRow(Ion::Events::Event event, int selectedRow) {
+  if (event.isKeyboardEvent()) {
+    uint8_t key = static_cast<uint8_t>(event.toKey());
+    uint8_t min = static_cast<uint8_t>(Ion::Keyboard::Key::Exp);
+    uint8_t max = static_cast<uint8_t>(Ion::Keyboard::Key::Plus) - min;
+    key-=min;
+    if (key >= 0 && key <= max) {
+      if (key <= numberOfRows()) {
+        return m_selectableTableView.selectCellAtClippedLocation(m_selectableTableView.selectedColumn(), key);
+      }
+    }
+  }
+  return NestedMenuController::handleEventForRow(event, selectedRow);
+}
+
 bool Toolbox::selectSubMenu(int selectedRow) {
   m_selectableTableView.deselectTable();
   m_messageTreeModel = static_cast<const ToolboxMessageTree *>(m_messageTreeModel->childAtIndex(selectedRow));

--- a/ion/include/ion/events.h
+++ b/ion/include/ion/events.h
@@ -34,6 +34,7 @@ public:
   bool isKeyboardEvent() const { return m_id < 4*PageSize; }
   bool isSpecialEvent() const { return m_id >= 4*PageSize; }
   bool isDefined() const;
+  Keyboard::Key toKey() const;
   static constexpr int PageSize = Keyboard::NumberOfKeys;
 private:
   const char * defaultText() const;

--- a/ion/src/shared/events.cpp
+++ b/ion/src/shared/events.cpp
@@ -60,6 +60,11 @@ bool Event::isDefined() const  {
   }
 }
 
+Keyboard::Key Event::toKey() const {
+  assert(isKeyboardEvent());
+  return static_cast<Keyboard::Key>(m_id % PageSize);
+}
+
 const char * Event::defaultText() const {
   /* As the ExternalText event is only available on the simulator, we save a
    * comparison by not handling it on the device. */


### PR DESCRIPTION
Navigation is done from A to Z, and doesn't mind the keyModifier selected (shit / alpha)