### PR TITLE
Fix selected text in dark mode

### DIFF
--- a/apps/calculation/history_view_cell.cpp
+++ b/apps/calculation/history_view_cell.cpp
@@ -81,7 +81,7 @@ void HistoryViewCell::reloadSubviewHighlight() {
   m_ellipsis.setHighlighted(false);
   if (isHighlighted()) {
     if (m_dataSource->selectedSubviewType() == HistoryViewCellDataSource::SubviewType::Input) {
-      m_inputView.setExpressionBackgroundColor(Palette::ListCellBackgroundSelected);
+      m_inputView.setExpressionBackgroundColor(Palette::Select);
     } else if (m_dataSource->selectedSubviewType() == HistoryViewCellDataSource::SubviewType::Output) {
       m_scrollableOutputView.evenOddCell()->setHighlighted(true);
     } else {

--- a/apps/code/script_node_cell.cpp
+++ b/apps/code/script_node_cell.cpp
@@ -21,10 +21,10 @@ void ScriptNodeCell::ScriptNodeView::drawRect(KDContext * ctx, KDRect rect) cons
   const int nodeNameLength = m_scriptNode->nameLength();
   KDSize nameSize = k_font->stringSize(nodeName, nodeNameLength);
   const KDCoordinate nodeNameY = k_topMargin;
-  ctx->drawString(nodeName, KDPoint(0, nodeNameY), k_font, KDColorBlack, backgroundColor, nodeNameLength);
+  ctx->drawString(nodeName, KDPoint(0, nodeNameY), k_font, Palette::PrimaryText, backgroundColor, nodeNameLength);
   // If it is needed, draw the parentheses
   if (m_scriptNode->type() == ScriptNode::Type::WithParentheses) {
-    ctx->drawString(ScriptNodeCell::k_parentheses, KDPoint(nameSize.width(), nodeNameY), k_font, KDColorBlack, backgroundColor);
+    ctx->drawString(ScriptNodeCell::k_parentheses, KDPoint(nameSize.width(), nodeNameY), k_font, Palette::PrimaryText, backgroundColor);
   }
 
   /* If it exists, draw the source name. If it did not fit, we would have put

--- a/apps/math_variable_box_empty_controller.cpp
+++ b/apps/math_variable_box_empty_controller.cpp
@@ -5,7 +5,7 @@
 
 MathVariableBoxEmptyController::MathVariableBoxEmptyView::MathVariableBoxEmptyView() :
   ModalViewEmptyView(),
-  m_layoutExample(0.5f, 0.5f, KDColorBlack, Palette::WallScreen)
+  m_layoutExample(0.5f, 0.5f, Palette::PrimaryText, Palette::WallScreen)
 {
   initMessageViews();
 }

--- a/apps/shared/scrollable_multiple_expressions_view.cpp
+++ b/apps/shared/scrollable_multiple_expressions_view.cpp
@@ -24,13 +24,13 @@ void AbstractScrollableMultipleExpressionsView::ContentCell::setHighlighted(bool
   // Do not call HighlightCell::setHighlighted to avoid marking all cell as dirty
   m_highlighted = highlight;
   KDColor defaultColor = backgroundColor();
-  KDColor color = highlight && m_selectedSubviewPosition == SubviewPosition::Center ? Palette::ExpressionInputBackground : defaultColor;
+  KDColor color = highlight && m_selectedSubviewPosition == SubviewPosition::Center ? Palette::Select : defaultColor;
   m_centeredExpressionView.setBackgroundColor(color);
-  color = highlight && m_selectedSubviewPosition == SubviewPosition::Right ? Palette::ExpressionInputBackground : defaultColor;
+  color = highlight && m_selectedSubviewPosition == SubviewPosition::Right ? Palette::Select : defaultColor;
   m_rightExpressionView.setBackgroundColor(color);
   m_approximateSign.setBackgroundColor(defaultColor);
   if (leftExpressionView()) {
-    color = highlight && m_selectedSubviewPosition == SubviewPosition::Left ? Palette::ExpressionInputBackground : defaultColor;
+    color = highlight && m_selectedSubviewPosition == SubviewPosition::Left ? Palette::Select : defaultColor;
     leftExpressionView()->setBackgroundColor(color);
   }
 }

--- a/themes/themes/local/epsilon_dark.json
+++ b/themes/themes/local/epsilon_dark.json
@@ -7,6 +7,7 @@
         "AccentText": "ffb734",
         "ApproximateSignText": "737373",
         "ApproximateExpressionText": "737373",
+        "Select": "1f1f1f",
         "Background": {
             "Hard": "000000",
             "Apps": "080605",

--- a/themes/themes/local/epsilon_dark.json
+++ b/themes/themes/local/epsilon_dark.json
@@ -51,11 +51,11 @@
             "BackgroundSelected": "2b281f",
             "Text": "ffffff",
             "Comment": "999988",
-            "Number": "009999",
-            "Keyword": "ff000c",
-            "Operator": "d73a49",
-            "String": "032f62",
-            "GutterViewBackground": "E4E6E7"
+            "Number": "1abc9c",
+            "Keyword": "c03535",
+            "Operator": "e67e22",
+            "String": "3498db",
+            "GutterViewBackground": "1f1f1f"
         },
         "Probability": {
             "Curve": "ffb734",
@@ -77,9 +77,9 @@
             "Text": "47443a"
         },
         "Toolbox": {
-            "HeaderBackground": "656975",
-            "HeaderText": "000000",
-            "HeaderBorder": "414147",
+            "HeaderBackground": "3b3b3b",
+            "HeaderText": "ffffff",
+            "HeaderBorder": "3b3b3b",
             "Background": "ffffff"
         },
         "List": {
@@ -98,11 +98,11 @@
             "Text": "ffffff"
         },
         "Tab": {
-            "Background": "4a4a4a",
+            "Background": "2e2e2e",
             "BackgroundSelected": "2b281f",
             "BackgroundActive": "000000",
             "BackgroundSelectedAndActive": "26272e",
-            "Text": "000000",
+            "Text": "ffffff",
             "TextActive": "656975"
         },
         "SubTab": {

--- a/themes/themes/local/omega_dark.json
+++ b/themes/themes/local/omega_dark.json
@@ -7,6 +7,7 @@
         "AccentText": "00857f",
         "ApproximateSignText": "a6a6a6",
         "ApproximateExpressionText": "a6a6a6",
+        "Select": "1f1f1f",
         "Background": {
             "Hard": "000000",
             "Apps": "050505",

--- a/themes/themes/local/omega_dark.json
+++ b/themes/themes/local/omega_dark.json
@@ -51,11 +51,11 @@
             "BackgroundSelected": "1f1f1f",
             "Text": "ffffff",
             "Comment": "999988",
-            "Number": "009999",
-            "Keyword": "ff000c",
-            "Operator": "d73a49",
-            "String": "032f62",
-            "GutterViewBackground": "E4E6E7"
+            "Number": "1abc9c",
+            "Keyword": "c03535",
+            "Operator": "e67e22",
+            "String": "3498db",
+            "GutterViewBackground": "1f1f1f"
         },
         "Probability": {
             "Curve": "00857f",
@@ -77,9 +77,9 @@
             "Text": "ffffff"
         },
         "Toolbox": {
-            "HeaderBackground": "b5b5b5",
-            "HeaderText": "000000",
-            "HeaderBorder": "b5b5b5",
+            "HeaderBackground": "3b3b3b",
+            "HeaderText": "ffffff",
+            "HeaderBorder": "3b3b3b",
             "Background": "ffffff"
         },
         "List": {
@@ -98,11 +98,11 @@
             "Text": "ffffff"
         },
         "Tab": {
-            "Background": "b5b5b5",
+            "Background": "2e2e2e",
             "BackgroundSelected": "8a8a8a",
             "BackgroundActive": "050505",
             "BackgroundSelectedAndActive": "1c1c1c",
-            "Text": "000000",
+            "Text": "ffffff",
             "TextActive": "ffffff"
         },
         "SubTab": {

--- a/themes/themes_manager.py
+++ b/themes/themes_manager.py
@@ -82,44 +82,52 @@ def write_palette_h(data, file_p):
     file_p.write("class Palette {\n")
     file_p.write("public:\n")
 
+    # Default values - sometimes never used
+    defaults = {
+        "YellowDark": "ffb734",
+        "YellowLight": "ffcc7b",
+        "PurpleBright": "656975",
+        "PurpleDark": "414147",
+        "GrayWhite": "f5f5f5",
+        "GrayBright": "ececec",
+        "GrayMiddle": "d9d9d9",
+        "GrayDark": "a7a7a7",
+        "GrayVeryDark": "8c8c8c",
+        "Select": "d4d7e0",
+        "SelectDark": "b0b8d8",
+        "WallScreen": "f7f9fa",
+        "WallScreenDark": "e0e6ed",
+        "SubTab": "b8bbc5",
+        "LowBattery": "f30211",
+        "Red": "ff000c",
+        "RedLight": "fe6363",
+        "Magenta": "ff0588",
+        "Turquoise": "60c1ec",
+        "Pink": "ffabb6",
+        "Blue": "5075f2",
+        "BlueLight": "718fee",
+        "Orange": "fe871f",
+        "Green": "50c102",
+        "GreenLight": "52db8f",
+        "Brown": "8d7350",
+        "Purple": "6e2d79",
+        "BlueishGrey": "919ea4",
+        "Cyan": "00ffff",
+    }
+
     for key in data["colors"].keys():
         if type(data["colors"][key]) is str:
             file_p.write("  constexpr static KDColor " + key + " = KDColor::RGB24(0x" + data["colors"][key] + ");\n")
+            if defaults.keys().__contains__(key):
+                del defaults[key]
         else:
             for sub_key in data["colors"][key].keys():
                 file_p.write("  constexpr static KDColor " + key + sub_key + " = KDColor::RGB24(0x" + data["colors"][key][sub_key] + ");\n")
+            if defaults.keys().__contains__(key+sub_key):
+                del defaults[key+sub_key]
 
-    # Default values - Sometimes never used
-    file_p.write("  constexpr static KDColor YellowDark = KDColor::RGB24(0xffb734);\n")
-    file_p.write("  constexpr static KDColor YellowLight = KDColor::RGB24(0xffcc7b);\n")
-    file_p.write("  constexpr static KDColor PurpleBright = KDColor::RGB24(0x656975);\n")
-    file_p.write("  constexpr static KDColor PurpleDark = KDColor::RGB24(0x414147);\n")
-    file_p.write("  constexpr static KDColor GrayWhite = KDColor::RGB24(0xf5f5f5);\n")
-    file_p.write("  constexpr static KDColor GrayBright = KDColor::RGB24(0xececec);\n")
-    file_p.write("  constexpr static KDColor GrayMiddle = KDColor::RGB24(0xd9d9d9);\n")
-    file_p.write("  constexpr static KDColor GrayDark = KDColor::RGB24(0xa7a7a7);\n")
-    file_p.write("  constexpr static KDColor GrayVeryDark = KDColor::RGB24(0x8c8c8c);\n")
-    file_p.write("  constexpr static KDColor Select = KDColor::RGB24(0xd4d7e0);\n")
-    file_p.write("  constexpr static KDColor SelectDark = KDColor::RGB24(0xb0b8d8);\n")
-    file_p.write("  constexpr static KDColor WallScreen = KDColor::RGB24(0xf7f9fa);\n")
-    file_p.write("  constexpr static KDColor WallScreenDark = KDColor::RGB24(0xe0e6ed);\n")
-    file_p.write("  constexpr static KDColor SubTab = KDColor::RGB24(0xb8bbc5);\n")
-    file_p.write("  constexpr static KDColor LowBattery = KDColor::RGB24(0xf30211);\n")
-    file_p.write("  constexpr static KDColor Red = KDColor::RGB24(0xff000c);\n")
-    file_p.write("  constexpr static KDColor RedLight = KDColor::RGB24(0xfe6363);\n")
-    file_p.write("  constexpr static KDColor Magenta = KDColor::RGB24(0xff0588);\n")
-    file_p.write("  constexpr static KDColor Turquoise = KDColor::RGB24(0x60c1ec);\n")
-    file_p.write("  constexpr static KDColor Pink = KDColor::RGB24(0xffabb6);\n")
-    file_p.write("  constexpr static KDColor Blue = KDColor::RGB24(0x5075f2);\n")
-    file_p.write("  constexpr static KDColor BlueLight = KDColor::RGB24(0x718fee);\n")
-    file_p.write("  constexpr static KDColor Orange = KDColor::RGB24(0xfe871f);\n")
-    file_p.write("  constexpr static KDColor Green = KDColor::RGB24(0x50c102);\n")
-    file_p.write("  constexpr static KDColor GreenLight = KDColor::RGB24(0x52db8f);\n")
-    file_p.write("  constexpr static KDColor Brown = KDColor::RGB24(0x8d7350);\n")
-    file_p.write("  constexpr static KDColor Purple = KDColor::RGB24(0x6e2d79);\n")
-    file_p.write("  constexpr static KDColor BlueishGrey = KDColor::RGB24(0x919ea4);\n")
-    file_p.write("  constexpr static KDColor Cyan = KDColorBlue;\n")
-    # End
+    for key in defaults.keys():
+        file_p.write("  constexpr static KDColor " + key + " = KDColor::RGB24(0x" + defaults[key] + ");\n")
 
     file_p.write("  constexpr static KDColor DataColor[] = {Red, Blue, Green, YellowDark, Magenta, Turquoise, Pink, Orange};\n")
     file_p.write("  constexpr static KDColor DataColorLight[] = {RedLight, BlueLight, GreenLight, YellowLight};\n")


### PR DESCRIPTION
Actually, in omega, in dark theme, when you select text, it's white on white background so it's a bit unreadable. This is a fix for that. It is just code from [Upsilon](htp://getupsilon.web.app).

Pull requests UpsilonNumworks/Upsilon#42, UpsilonNumworks#49 & UpsilonNumworks/Upsilon#51
Issue: #537

Credits to @lolocomotive & @Syycorax.